### PR TITLE
fix 500 when viewing share when not signed in

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -43,16 +43,18 @@ class BoardsController < ApplicationController
 
   def share
     @board = Board.find(params[:id])
-    if (@board.owned_by?(current_user))
+    if !user_signed_in?
+      flash[:warning] = "You must be signed in to view that page"
+      redirect_to root_path
+    elsif (@board.owned_by?(current_user))
       redirect_to board_path(@board)
-
     elsif !current_user.supporter_for(@board)
       flash[:warning] = "You do not have access to that page"
       redirect_to user_path(current_user)
+    else
+      @unaccepted_tasks = @board.unaccepted_tasks
+      @user_tasks = current_user.tasks_from_board(@board)
     end
-
-    @unaccepted_tasks = @board.unaccepted_tasks
-    @user_tasks = current_user.tasks_from_board(@board)
   end
 
   private

--- a/test/controllers/boards_controller_test.rb
+++ b/test/controllers/boards_controller_test.rb
@@ -67,6 +67,13 @@ class BoardsControllerTest < ActionController::TestCase
     assert_redirected_to board_path(board)
   end
 
+  test "share should redirect for users who are not signed in" do
+    sign_out @owner
+    get :share, id: @user.boards.first.id
+    assert_redirected_to root_path
+    assert_match "signed in", flash[:warning]
+  end
+
   test "supporters should be able to view available tasks and their own tasks" do
     sign_in @user
     board = create(:board_with_tasks)


### PR DESCRIPTION
Checked if anyone was signed in before doing other checks about the user.  Added a controller test to catch this case.
