### PR TITLE
Integration tests with capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'annotate',             '2.6.5'
 gem 'simple_calendar',      '1.1.1'
 gem 'simple_form'
 gem 'devise'
+gem 'capybara'
 
 gem 'foundation-rails',     '5.4.5'
 gem 'font-awesome-rails',   '4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,12 @@ GEM
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
@@ -241,6 +247,8 @@ GEM
       binding_of_caller (= 0.7.3.pre1)
       railties (~> 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -248,6 +256,7 @@ PLATFORMS
 DEPENDENCIES
   annotate (= 2.6.5)
   byebug (= 3.4.0)
+  capybara
   coffee-rails (= 4.1.0)
   devise
   factory_girl_rails (= 4.5.0)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-categories = {food: %w(Groceries Delivery Prepared\ Food), 
+categories = {food: %w(Groceries Delivery Prepared\ Food),
               household: %w(Cleaning Laundry Supplies Yardwork Handyman Carwash),
               petcare: %w(Dogwalking Grooming Clean\ Up),
               childcare: %w(Care Babysit Pick-up/Drop-Off Homework\ Help),
@@ -9,10 +9,7 @@ categories = {food: %w(Groceries Delivery Prepared\ Food),
 
 
 categories.each do | cat, typeList |
-  typeList.each do |type| 
+  typeList.each do |type|
     TaskType.create(name: type, category: cat)
   end
 end
-
-Signup.create(email: "foo@bar.com", first_name: "Foo", last_name: "Bar")
-Board.create(email: "foo@bar.com", name: "Foo Bar")

--- a/test/integration/board_owners_and_tasks_test.rb
+++ b/test/integration/board_owners_and_tasks_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class BoardOwnersAndTasksTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = create(:user)
+    @board = create(:board, name: "board name", description: "board description")
+    @board.add_owner(@user)
+    sign_in_with_form(@user)
+  end
+
+  test "owners see their owned boards" do
+    visit(user_path(@user))
+    assert page.has_content?(@board.name)
+    assert page.has_content?(@board.description)
+    assert page.has_content?("Create a new board")
+  end
+
+  test "users can add new boards and own them" do
+    visit(user_path(@user))
+    assert_difference -> { @user.owned_boards.count }, +1 do
+      click_link("Create a new board")
+      fill_in("Name", with: "second")
+      fill_in("Description", with: "second")
+      click_button("Create board")
+    end
+
+    assert page.has_content?("Board created successfully")
+    assert page.has_content?("second")
+  end
+
+  test "owners can add a task" do
+    visit(board_path(@board))
+
+    assert page.has_content?("Add a new task:")
+    assert page.has_content?("Your tasks")
+
+    within("#deliveryModal") do
+      fill_in 'Title', with: "title"
+      fill_in 'Description', with: "description"
+      click_button "Add task"
+    end
+
+    assert page.has_selector?(".task-info")
+  end
+end

--- a/test/integration/user_sign_in_test.rb
+++ b/test/integration/user_sign_in_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class UserSignInTest < ActionDispatch::IntegrationTest
+  test "users can sign in" do
+    user = create(:user)
+    sign_in_with_form(user)
+
+    assert_equal user_path(user), current_path
+    assert page.has_content?('Boards you support')
+  end
+
+  test "users can sign up" do
+    assert_difference -> { User.count }, +1 do
+      visit('/users/sign_up')
+      fill_in('First name', with: "Bob")
+      fill_in('Last name', with: "Smith")
+      fill_in('Email', with: "bobsmith@example.com")
+      fill_in('* Password', with: "foobar123", exact: true)
+      fill_in('Password confirmation', with: "foobar123")
+      click_button("Sign up")
+    end
+
+    assert_match 'users/', current_path
+    assert page.has_content?('Welcome')
+  end
+
+  test "users can sign out" do
+    user = create(:user)
+    sign_in_with_form(user)
+    click_link("Sign out")
+
+    assert_equal root_path, current_path
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 require 'capybara/rails'
 require 'simplecov'
+
 SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/reporters'
@@ -12,8 +14,9 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  include(FactoryGirl::Syntax::Methods)
+  include FactoryGirl::Syntax::Methods
 end
+
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'capybara/rails'
 require 'simplecov'
 SimpleCov.start 'rails'
 
@@ -10,6 +11,18 @@ Minitest::Reporters.use!
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
-  
+
   include(FactoryGirl::Syntax::Methods)
+end
+
+class ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  def sign_in_with_form(user)
+    visit('/users/sign_in')
+
+    fill_in('Email', with: user.email)
+    fill_in('Password', with: user.password)
+    click_button('Log in')
+  end
 end


### PR DESCRIPTION
- Add caybara to Gemfile
- add capybara to test helpers, and sign_in_with_form method to manually sign in users with the web form (as opposed to with devise helpers)
- wrote integration tests for signing users in and out, as well as signing them up.
- integration tests for adding a task to a board as an owner.

NOTE about database:

These tests made apparent some problems in our test database.  The solution, for now, was to run `rake db:reset RAILS_ENV=test`, which seems to fix things and also seed the database appropriately.   I'm not sure if this will suffice onwards, but allows the test suite to pass.

It's currently failing on Circle, I think it might have something to do with the test database there too, do we need to seed it?
